### PR TITLE
Mistake in Version compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Schema.org Breadcrumbs for WordPress SEO
 ========================================
 
-[![endorse](https://api.coderwall.com/felixarntz/endorsecount.png)](https://coderwall.com/felixarntz)
+[![endorse](https://coderwall-assets-0.s3.amazonaws.com/uploads/user/avatar/105962/IMG_4758quadrat.jpg)](https://coderwall.com/felixarntz)
 
 With this class the WordPress SEO breadcrumbs will use valid Schema.org markup.
 

--- a/class.schema_breadcrumbs.php
+++ b/class.schema_breadcrumbs.php
@@ -122,7 +122,7 @@ class Schema_Breadcrumbs
   public function modify_breadcrumb_output( $full_output )
   {
     $string_to_replace = ' prefix="v: http://rdf.data-vocabulary.org/#"';
-    if( version_compare( WPSEO_VERSION, '1.5.3.3', '<' ) )
+    if( version_compare( WPSEO_VERSION, '1.5.3.3', '>' ) )
     {
       $string_to_replace = ' xmlns:v="http://rdf.data-vocabulary.org/#"';
     }


### PR DESCRIPTION
More than...
Current Version of Yoast - 4.4 and it use ' xmlns:v="http://rdf.data-vocabulary.org/#"', so '>'