### PR TITLE
Change real version of WordPress SEO plugin to test string value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/nbproject/

--- a/class.schema_breadcrumbs.php
+++ b/class.schema_breadcrumbs.php
@@ -7,7 +7,7 @@
  * License:       GNU General Public License
  * License URI:   http://www.opensource.org/licenses/gpl-license.php GPL v2.0 (or later)
  */
- 
+
 /**
  * This class modifies the breadcrumbs from the WordPress SEO plugin by Yoast to use Schema.org markup instead of RDFa.
  * It uses a singleton pattern so that it can only be instantiated once.
@@ -20,18 +20,18 @@
  *    }
  * }
  * add_action( 'after_setup_theme', 'yourtheme_instantiate_class' );</code>
- * 
+ *
  * The content is modified using the following plugin filters:
  * - 'wpseo_breadcrumb_single_link'
  * - 'wpseo_breadcrumb_output'
- * 
+ *
  * This class will not do anything if the WordPress SEO plugin is not installed:
  * http://yoast.com/wordpress/seo/
- * 
+ *
  * @package WPSEO_SchemaBreadcrumbs
  * @version 1.3.1
  * @author Felix Arntz <felix-arntz@leaves-and-love.net>
- * 
+ *
  */
 class Schema_Breadcrumbs
 {
@@ -41,7 +41,7 @@ class Schema_Breadcrumbs
 
   /**
    * Singleton Pattern
-   * 
+   *
    * @return Schema_Breadcrumbs instance of the class
    */
   public static function instance()
@@ -52,10 +52,10 @@ class Schema_Breadcrumbs
     }
     return self::$instance;
   }
-  
+
   /**
    * Constructor of the class
-   * 
+   *
    * Adds the modifying functions to the four WordPress SEO plugin filters.
    */
   private function __construct()
@@ -63,16 +63,16 @@ class Schema_Breadcrumbs
     add_filter( 'wpseo_breadcrumb_single_link', array( $this, 'modify_breadcrumb_element' ), 10, 2 );
     add_filter( 'wpseo_breadcrumb_output', array( $this, 'modify_breadcrumb_output' ) );
   }
-  
+
   /**
    * This function modifies the output for a single breadcrumb.
-   * 
+   *
    * The default output is not modified, instead a completely new output is generated.
    * If the default link output contains a rel attribute with the value 'v:url' (which is added by WordPress SEO for every but the last link), URL and text are output.
    * Otherwise it is the current page for which only the text is printed out.
-   * 
+   *
    * In this method the Schema.org markup for a single breadcrumb is added, and the link counter (class variable) is increased by 1 (for each link).
-   * 
+   *
    * @param string $link_output the default output created by the WordPress SEO plugin
    * @param array $link an array containing data for the breadcrumb link (with fields 'url' and 'text')
    * @return string the output for a single breadcrumb link
@@ -80,7 +80,7 @@ class Schema_Breadcrumbs
   public function modify_breadcrumb_element( $link_output, $link )
   {
     $output = '';
-    
+
     if( isset( $link['url'] ) && substr_count( $link_output, 'rel="v:url"' ) > 0 )
     {
       $output .= '<a href="' . esc_attr( $link['url'] ) . '"><span itemprop="itemListElement">' . $link['text'] . '</span></a>';
@@ -107,27 +107,27 @@ class Schema_Breadcrumbs
     }
 
     $this->breadcrumb_link_counter++;
-    
+
     return $output;
   }
-  
+
   /**
    * This function modifies the overall breadcrumbs output.
-   * 
+   *
    * The default output is directly modified: The RDFa markup is replaced by equivalent Schema.org markup.
-   * 
+   *
    * @param string $full_output the default output created by the WordPress SEO plugin
    * @return string the overall breadcrumbs output
    */
   public function modify_breadcrumb_output( $full_output )
   {
     $string_to_replace = ' prefix="v: http://rdf.data-vocabulary.org/#"';
-    if( version_compare( WPSEO_VERSION, '1.5.3.3', '<' ) )
+    if( version_compare( WPSEO_VERSION, '2.0.1', '>' ) )
     {
       $string_to_replace = ' xmlns:v="http://rdf.data-vocabulary.org/#"';
     }
     $output = str_replace( $string_to_replace, ' itemprop="breadcrumb" itemscope="itemscope" itemtype="http://schema.org/BreadcrumbList"', $full_output );
-    
+
     return $output;
   }
 }


### PR DESCRIPTION
Change real version of WordPress SEO plugin to test string value RDFa wrapper + inverse comparison operator.

Hi,

Thanks for this very useful class :-)

The real version the RDFa wrapper changed is after WordPress SEO 2.0.1 version
https://github.com/Yoast/wordpress-seo/blob/2.0.1/frontend/class-breadcrumbs.php
where the string to replace is  prefix="v: ...

Since the 2.1 version 
https://github.com/Yoast/wordpress-seo/blob/2.1/frontend/class-breadcrumbs.php
the string to replace is  xmlns:v=" .....

So version to compare with is not 1.5.3.3 but 2.0.1
The comparison operator is also the inverse operator, not < but > 

I tested with WordPress SEO 4.5 and it works fine.

Best Regards
Emmanuel

